### PR TITLE
Standard Platform module now provides a token

### DIFF
--- a/scala.stdplatform/src/main/nbm/manifest.mf
+++ b/scala.stdplatform/src/main/nbm/manifest.mf
@@ -4,4 +4,5 @@ AutoUpdate-Show-In-Client: true
 OpenIDE-Module-Localizing-Bundle: org/netbeans/modules/scala/stdplatform/resources/Bundle.properties
 OpenIDE-Module-Layer: org/netbeans/modules/scala/stdplatform/resources/layer.xml
 OpenIDE-Module-Install: org/netbeans/modules/scala/stdplatform/J2SEPlatformModule.class
+OpenIDE-Module-Provides: org.netbeans.modules.scala.stdplatform
 


### PR DESCRIPTION
In order to be add weak dependency on Scala Platform module, this module has to provide a token.

See: http://bits.netbeans.org/8.0/javadoc/org-openide-modules/org/openide/modules/doc-files/api.html#how-vers

So this commit makes other modules to be able to require of/depend on the existence of Scala Standard Platform module (and naturally it's dependencies). Like for groovy: cnb.org.netbeans.modules.groovy.kit